### PR TITLE
feat(questions): add question detial page

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-router-dom": "^5",
+    "remarkable": "^2.0.1",
     "vditor": "^3.8.13"
   },
   "devDependencies": {

--- a/src/components/Standard/StandardMDContainer.tsx
+++ b/src/components/Standard/StandardMDContainer.tsx
@@ -8,7 +8,13 @@ export const StandardMDContainer = ({ text }: { text?: string }) => {
 
   React.useEffect(() => {
     if (isNotNil(text) && ref.current) {
-      Vditor.preview(ref.current, text);
+      Vditor.preview(ref.current, text, {
+      	math: {
+          engine: 'MathJax'
+      	},
+        after: () => window?.MathJax?.loader?.ready?.()
+          ?.then( () => window.MathJax.typeset([document.body]) )
+      });
     }
   }, [ref.current]);
 

--- a/src/modules/Questions/QuestionDetailPage.tsx
+++ b/src/modules/Questions/QuestionDetailPage.tsx
@@ -1,0 +1,84 @@
+import { StandardMDContainer } from '@/components/Standard/StandardMDContainer';
+import { QuestionModel } from '@/generated-api/Api';
+import { api } from '@/utils/api';
+import moment from 'moment';
+import { useRequest } from 'ahooks';
+import {
+  Layout,
+  Skeleton,
+  Tabs,
+  Divider,
+  Typography,
+  PageHeader,
+  Row, 
+  Col,
+  Tag,
+} from 'antd';
+import moment from 'moment';
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const { Content } = Layout;
+const { TabPane } = Tabs;
+const { Title } = Typography;
+
+function QuestionDetail({ question }: { question: QuestionModel }) {
+  return (
+    <Content>
+      <PageHeader 
+      	  title={question.title}
+          onBack={() => window.history.back()}
+          style={{positive: "relative", padding: 0}}
+        >
+      </PageHeader>
+      <Divider />
+      <Row span={24}>
+      	  <Col>难度: <Tag color="red">困难</Tag></Col>
+      	  <Col offset={1}>创建时间: {moment(question.created_at).format('YYYY-MM-DD')}</Col>
+      	  <Col offset={1}>创建者: {question.author}</Col>
+      </Row>
+
+      <Tabs defaultActiveKey="1" size={'large'}>
+        <TabPane tab="题目描述" key={1}>
+          <StandardMDContainer
+            text={question.description}
+          ></StandardMDContainer>
+        </TabPane>
+        <TabPane tab="题解" key={2}>
+          <StandardMDContainer
+            text={question.solution}
+		  ></StandardMDContainer>
+        </TabPane>
+        <TabPane tab="分析" key={3}>
+          <StandardMDContainer
+            text={question.analysis}
+		  ></StandardMDContainer>
+        </TabPane>
+      </Tabs>
+    </Content>
+  );
+}
+
+export function QuestionDetailPage({ id }: { id: string }) {
+  const { data, loading } = useRequest(
+    () => {
+      return api.question.questionRetrieve(id);
+    },
+    { refreshDeps: [id] }
+  );
+  const question = data?.data;
+
+  console.log(question)
+
+  return (
+    <Skeleton
+      avatar
+      active
+      title={false}
+      paragraph={{ rows: 18 }}
+      loading={loading || !question}
+    >
+      <QuestionDetail question={question} />
+    </Skeleton>
+  );
+}

--- a/src/modules/Questions/QuestionSetNodeEditingPage.tsx
+++ b/src/modules/Questions/QuestionSetNodeEditingPage.tsx
@@ -1,8 +1,10 @@
 import { StandardPageLayout } from '@/components/Standard/StandardPageLayout';
 import { api } from '@/utils/api';
+import { QuestionSetNodeModel } from '@/generated-api/Api';
 import { useRequest } from 'ahooks';
-import { Spin } from 'antd';
+import { Spin, Table } from 'antd';
 import React from 'react';
+import { Link, Route, useRouteMatch } from 'react-router-dom';
 
 interface Props {
   questionNodeId: number;
@@ -16,14 +18,30 @@ export function QuestionSetNodeEditingPage({ questionNodeId }: Props) {
     { refreshDeps: [questionNodeId] }
   );
 
-  const dataSource = data?.data;
+  var questionSet = data?.data;
+  questionSet = questionSet?.id ? [questionSet] : questionSet;
 
+  const columns = [
+    {
+      title: '习题集名',
+      dataIndex: 'label',
+      key: 'label',
+      render: (label: string, row: QuestionSetNodeModel) => {
+        const path = {
+          pathname: `/questions/${row?.question}`,
+        }
+        return row.children?.[0] ? <span>{label}</span> : <Link to={path}>{label}</Link>
+      },
+    }
+  ];
   return (
-    <StandardPageLayout title="习题集详情">
-      开发中
-      {/* TODO 实现习题集详情展示。请求数据的使用例如下 */}
-      {/* id: {questionNodeId}
-      <Spin spinning={loading}>{JSON.stringify(dataSource)}</Spin> */}
+    <StandardPageLayout title={"习题集详情"}>
+      <Table
+        columns={columns}
+        dataSource={questionSet}
+        loading={loading}
+        rowKey="id"
+      />
     </StandardPageLayout>
   );
 }

--- a/src/modules/Questions/QuestionsPage.tsx
+++ b/src/modules/Questions/QuestionsPage.tsx
@@ -8,10 +8,11 @@ import { default as React, FC } from 'react';
 import { Link, Route, Switch } from 'react-router-dom';
 import { QuestionEditingPage } from './QuestionEditingPage';
 import { QuestionSetNodeEditingPage } from './QuestionSetNodeEditingPage';
+import { QuestionDetailPage } from './QuestionDetailPage';
 
 export function QuestionList() {
   const { data, loading } = useRequest(api.question.questionList);
-  const courses = data?.data;
+  const questions = data?.data;
 
   const columns = [
     {
@@ -51,12 +52,12 @@ export function QuestionList() {
     },
   ];
 
-  return <Table columns={columns} dataSource={courses} loading={loading} />;
+  return <Table columns={columns} dataSource={questions} loading={loading} />;
 }
 
 export function QuestionSetList() {
   const { data, loading } = useRequest(api.questionSet.questionSetList);
-  const courses = data?.data;
+  const questionSet = data?.data;
 
   const columns = [
     {
@@ -75,7 +76,7 @@ export function QuestionSetList() {
   return (
     <Table
       columns={columns}
-      dataSource={courses}
+      dataSource={questionSet}
       loading={loading}
       rowKey="id"
       expandable={{ childrenColumnName: 'N/A' }}
@@ -130,8 +131,8 @@ export const QuestionsPage: FC<unknown> = () => {
         path="/questions/:id"
         render={(props) => {
           return (
-            <StandardPageLayout title="题目内容">
-              id: {props.match.params.id}
+            <StandardPageLayout title="题目详情">
+              <QuestionDetailPage id={props.match.params.id} ></QuestionDetailPage>
             </StandardPageLayout>
           );
         }}

--- a/src/styles/index.less
+++ b/src/styles/index.less
@@ -79,3 +79,8 @@ code {
   height: 240px;
 }
 
+/* Vditor */
+
+.vditor-reset {
+  overflow: hidden !important;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,7 +1095,7 @@ arg@^4.1.0:
   resolved "https://registry.npmmirror.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
   integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
-argparse@^1.0.7:
+argparse@^1.0.10, argparse@^1.0.7:
   version "1.0.10"
   resolved "https://registry.npmmirror.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
@@ -1156,6 +1156,13 @@ async-validator@^4.0.2:
   version "4.0.7"
   resolved "https://registry.npmmirror.com/async-validator/-/async-validator-4.0.7.tgz#034a0fd2103a6b2ebf010da75183bec299247afe"
   integrity sha512-Pj2IR7u8hmUEDOwB++su6baaRi+QvsgajuFB9j95foM1N2gy5HM4z60hfusIO0fBPG5uLAEl6yCJr1jNSVugEQ==
+
+autolinker@^3.11.0:
+  version "3.15.0"
+  resolved "https://registry.npmmirror.com/autolinker/-/autolinker-3.15.0.tgz#03956088648f236642a5783612f9ca16adbbed38"
+  integrity sha512-N/5Dk5AZnqL9k6kkHdFIGLm/0/rRuSnJwqYYhLCJjU7ZtiaJwCBzNTvjzy1zzJADngv/wvtHYcrPHytPnASeFA==
+  dependencies:
+    tslib "^2.3.0"
 
 axios@^0.21.4:
   version "0.21.4"
@@ -4385,6 +4392,14 @@ remark-parse@^9.0.0:
   integrity sha512-geKatMwSzEXKHuzBNU1z676sGcDcFoChMK38TgdHJNAYfFtsfHDQG7MoJAjs6sgYMqyLduCYWDIWZIxiPeafEw==
   dependencies:
     mdast-util-from-markdown "^0.8.0"
+
+remarkable@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmmirror.com/remarkable/-/remarkable-2.0.1.tgz#280ae6627384dfb13d98ee3995627ca550a12f31"
+  integrity sha512-YJyMcOH5lrR+kZdmB0aJJ4+93bEojRZ1HGDn9Eagu6ibg7aVZhc3OWbbShRid+Q5eAfsEqWxpe+g5W5nYNfNiA==
+  dependencies:
+    argparse "^1.0.10"
+    autolinker "^3.11.0"
 
 repeat-string@^1.0.0:
   version "1.6.1"


### PR DESCRIPTION
- 添加树组件, 展示习题集详情页
- 添加习题详情页, 展示习题信息.

bugs:

 - Vditor数学公式渲染有问题, 包括不能渲染$$以及$$$$以外的数学环境, 如align, equation等.
- 以及多行数学公式行首如果是加减号, 则被认为是markdown字符.
- 两个反斜杠(换行符)变成一个.

Todos

- 考虑把katex转为mathjax. 前者不完全支持latex数学公式, 后者更专业. 在内容不是特别多的情况下, mathjax性能足够.